### PR TITLE
avoid making AWS and AWS-CI the same object

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -138,7 +138,8 @@ services:
       # ssh_private_key: relative/path
       # user: the_username
     # install_base_domain: my.route53.domain.example.com
-  AWS-CI: *AWSBase
+  AWS-CI:
+    <<: *AWSBase
   azure:
     # auth:
     #   # az login --service-principal -u client_id --tenant tenant_id


### PR DESCRIPTION
hotfix, didn't realize old format will make the same object and then 
further config will apply to both places where it should only apply to one of them